### PR TITLE
Main menu design

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -4,7 +4,11 @@
     overflow: auto;
 }
 
-
+.loginBtn {
+    background-color: #add8ff !important;
+    color: #004480 !important;
+    /*border: 1px solid #004480;*/
+}
 
 ::placeholder {
     color: black;

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -6,6 +6,7 @@
 
 .landingMain {
     height: 75vh;
+    padding: 10vh;
 }
 
 .registerBtn {
@@ -18,7 +19,7 @@
     color: #004480 !important;
     width: 140px;
     border-radius: 3px;
-    letter-spacing: 1.5px
+    letter-spacing: 1.5px;
 }
 
 ::placeholder {
@@ -27,7 +28,7 @@
 
 .blurb {
     color: grey;
-    font-size: 2rem;
+    font-size: 1.4rem !important;
 }
 
 #left {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -4,14 +4,30 @@
     overflow: auto;
 }
 
+.landingMain {
+    height: 75vh;
+}
+
+.registerBtn {
+    width: 140px;
+    border-radius: 3px;
+    letter-spacing: 1.5px
+}
 .loginBtn {
     background-color: #add8ff !important;
     color: #004480 !important;
-    /*border: 1px solid #004480;*/
+    width: 140px;
+    border-radius: 3px;
+    letter-spacing: 1.5px
 }
 
 ::placeholder {
     color: black;
+}
+
+.blurb {
+    color: grey;
+    font-size: 2rem;
 }
 
 #left {

--- a/client/src/components/layout/Landing.js
+++ b/client/src/components/layout/Landing.js
@@ -7,7 +7,7 @@ class Landing extends Component {
             <div className="landingMain container valign-wrapper">
                 <div className="row">
                     <div className="col s12 center-align">
-                        <p className="flow-text grey-text text-darken-1">
+                        <p className="blurb flow-text grey-text text-darken-1">
                             Use Aggie Registration Alert to be notified when filled classes become available!
                         </p>
                         <br />

--- a/client/src/components/layout/Landing.js
+++ b/client/src/components/layout/Landing.js
@@ -32,7 +32,7 @@ class Landing extends Component {
                   borderRadius: "3px",
                   letterSpacing: "1.5px"
                 }}
-                className="btn btn-large btn-flat waves-effect white black-text"
+                className="loginBtn btn btn-large btn-flat waves-effect white black-text hoverable"
               >
                 Log In
               </Link>

--- a/client/src/components/layout/Landing.js
+++ b/client/src/components/layout/Landing.js
@@ -2,46 +2,36 @@ import React, { Component } from "react";
 import { Link } from "react-router-dom";
 
 class Landing extends Component {
-  render() {
-    return (
-      <div style={{ height: "75vh" }} className="container valign-wrapper">
-        <div className="row">
-          <div className="col s12 center-align">
-            <p className="flow-text grey-text text-darken-1">
-                Use Aggie Registration Alert to be notified when filled classes become available!
-            </p>
-            <br />
-            <div className="col s6">
-              <Link
-                to="/register"
-                style={{
-                  width: "140px",
-                  borderRadius: "3px",
-                  letterSpacing: "1.5px"
-                }}
-                className="btn btn-large waves-effect waves-light hoverable blue accent-3"
-              >
-                Register
-              </Link>
+    render() {
+        return (
+            <div className="landingMain container valign-wrapper">
+                <div className="row">
+                    <div className="col s12 center-align">
+                        <p className="flow-text grey-text text-darken-1">
+                            Use Aggie Registration Alert to be notified when filled classes become available!
+                        </p>
+                        <br />
+                        <div className="col s6">
+                            <Link
+                                to="/register"
+                                className="registerBtn btn btn-large waves-effect waves-light hoverable blue accent-3"
+                            >
+                                Register
+                            </Link>
+                        </div>
+                        <div className="col s6">
+                            <Link
+                                to="/login"
+                                className="loginBtn btn btn-large btn-flat waves-effect white black-text"
+                            >
+                                Log In
+                            </Link>
+                        </div>
+                    </div>
+                </div>
             </div>
-            <div className="col s6">
-              <Link
-                to="/login"
-                style={{
-                  width: "140px",
-                  borderRadius: "3px",
-                  letterSpacing: "1.5px"
-                }}
-                className="loginBtn btn btn-large btn-flat waves-effect white black-text hoverable"
-              >
-                Log In
-              </Link>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+        );
+    }
 }
 
 export default Landing;


### PR DESCRIPTION
Made the landing page a bit prettier, including making the login button a lighter blue rather than just plain white (it faded into the background that way), and making the blurb font size smaller.

Also, transferred the inline styling for the landing page into the App.css because it was _way_ easier for me to work with.

Regarding the big red block of code that I seemingly deleted and then replaced, I messed up on the code so I literally just copied and pasted from the master branch here on github.